### PR TITLE
Add single quote handling for unescaped strings

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -26,6 +26,13 @@ let tests =
     "foo \"bar\" baz", ["foo"; "bar"; "baz"];
     "f\\\ oo b\\\"r baz", ["f oo"; "b\"r"; "baz"];
     "foo bar\"bie\"boo baz", ["foo"; "barbieboo"; "baz"];
+    "foo 'bar' baz", ["foo"; "bar"; "baz"];
+    "foo bar'bie'boo baz", ["foo"; "barbieboo"; "baz"];
+    "foo 'b a\"r' baz", ["foo"; "b a\"r"; "baz"];
+    "foo \"b a'r\" baz", ["foo"; "b a'r"; "baz"];
+    "foo b\\ a\\'r baz", ["foo"; "b a'r"; "baz"];
+    "foo \"b\\\\\\ a\\\"r\" baz", ["foo"; "b\\ a\"r"; "baz"];
+    "foo 'b\\\\\\ a\\\"r' baz", ["foo"; "b\\\\\\ a\\\"r"; "baz"];
     "  ", []
   ]
 


### PR DESCRIPTION
Parse_argv handles `\` and `"` as special characters in any context, which makes the usage of boot parameters containing these characters &ndash; like JSON strings &ndash; very tedious.  This change introduces the handling of single quoted text ('foobar'), that - like in typical shell command line parsing - is interpreted as verbatim text without any special escape handling.  The only character that has special handling is the single quote `'` itself, which ends the single quoted text and therefore can't appear within single quoted text. (Also `\'` is not supported.) Now for example this command:
```
$ ./solo5-hvt --net=tap100 ./app.hvt --json '{\"foo\":\ \"bar\"}'
```
can instead be written as
```
$ ./solo5-hvt --net=tap100 ./app.hvt --json \''{"foo": "bar"}'\'
```

Related: Solo5/solo5#281
Related: Solo5/solo5#283
Related: mirage/mirage-solo5#33
