### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/parse-argv.opam
+++ b/parse-argv.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/parse-argv/"
 bug-reports: "https://github.com/mirage/parse-argv/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ounit" {with-test}
   "astring"
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.