### PR TITLE
Parse empty quoted strings

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -29,6 +29,8 @@ let tests =
     {|foo "bar baz"|}, ["foo"; "bar baz"];
     {|foo bar\ baz|}, ["foo"; "bar baz"];
     "  ", [];
+    {|"" is empty|}, [""; "is"; "empty"];
+    {|some-empty-string: ""|}, ["some-empty-string:"; ""];
   ]
 
 let test_parse () =


### PR DESCRIPTION
This allows passing arguments that are the empty string: `--sep ""` is parsed as `["--sep"; ""]`.

It's achieved by keeping track of the previous state. If we had just seen an end of quote we unconditionally add the string - even if it's the empty string.